### PR TITLE
fix when enabling production mode - TypeError: can't access property …

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/simplifycommerce-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/simplifycommerce-method.js
@@ -118,7 +118,8 @@ define([
 
             requirejs.load({
                 contextName: '_',
-                onScriptLoad: this.adapterLoaded.bind(this)
+                onScriptLoad: this.adapterLoaded.bind(this),
+                config: this.getConfig()
             }, this.getCode(), this.getConfig()['js_component_url']);
 
             return this;


### PR DESCRIPTION
When enabling production mode the method won't appear in frontend in Magento 2.2.11

I think it applies to next versions too because the function needs the same data in the newest versions.

Without this an error is thrown, 

`TypeError: can't access property "baseUrl", config is undefined`

and the method doesn't appear in the frontend.