### PR TITLE
Fixed an issue where payment amounts were incorrect due to rounding errors

### DIFF
--- a/Gateway/Request/PaymentBuilder.php
+++ b/Gateway/Request/PaymentBuilder.php
@@ -30,7 +30,7 @@ class PaymentBuilder implements BuilderInterface
     {
         $paymentDO = SubjectReader::readPayment($buildSubject);
         $order = $paymentDO->getOrder();
-        $amount = (int) ((float) SubjectReader::readAmount($buildSubject) * 100);
+        $amount = (int) round((float) SubjectReader::readAmount($buildSubject) * 100);
 
         return [
             'amount' => $amount,

--- a/Gateway/Validator/PaymentValidator.php
+++ b/Gateway/Validator/PaymentValidator.php
@@ -35,7 +35,7 @@ class PaymentValidator extends AbstractValidator
         $simplifyPayment = $response['object'];
 
         $paymentDO = SubjectReader::readPayment($validationSubject);
-        $amount = (int) ((float) SubjectReader::readAmount($validationSubject) * 100);
+        $amount = (int) round((float) SubjectReader::readAmount($validationSubject) * 100);
 
         $order = $paymentDO->getOrder();
 


### PR DESCRIPTION
This pull request fixes an issue where amounts were being calculated incorrectly due to the way that PHP handles casting floats to integers. The problem code is exists both for calculating the amount that is to be paid and when validating that the paid amount matches the expected amount.

For example, the payment total is calculated using `$amount = (int) ((float) SubjectReader::readAmount($buildSubject) * 100);` and let's use `1268.10` as the return value of `SubjectReader::readAmount($buildSubject)`. Evaluating `(int) ((float) 1268.10 * 100)` returns the result `int(126809)` which is one cent less than the actual order total.

Out of curiosity, I ran some basic tests to see how often this might occur, and for order totals ranging from $0.01 to $100,000.00 it occurred 587,200 times (PHP 7.4.3).

The fix was just to round the value prior to casting it to an integer, although I have left this pull request as a draft for now because that is not necessarily the _ideal_ solution. 

You may or may not want to implement an alternative solution which utilises PHP's arbitrary precision math functions, or perhaps  something purpose built for handling money such as [https://github.com/moneyphp/money](https://github.com/moneyphp/money).